### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ setup(
 
     description='A tool to enumerate information from NTLM authentication enabled web endpoints',  # Optional
 
+    license='MIT',
+    
     long_description=long_description,  # Optional
 
     long_description_content_type='text/markdown',  # Optional (see note above)


### PR DESCRIPTION
Allow third-party tools (e. g., PyPI or `pyp2rpm`) to get the license details in a simple way.